### PR TITLE
fix: preserve fan speed and swing settings when controlling via HomeKit

### DIFF
--- a/homebridge-mitsubishi-wfrac/encoder/airconStat.js
+++ b/homebridge-mitsubishi-wfrac/encoder/airconStat.js
@@ -66,14 +66,45 @@ export function generateAirconStat(power, tempC, mode = 'cool') {
   return Buffer.concat([cmd, rcv]).toString('base64');
 }
 
-// Rebuilds the stat from already-read command bytes, modifying only power/mode/temp.
-// All other bytes (fan speed, swing, vane, etc.) are preserved from the device's current state.
-export function rebuildAirconStat(cmdBytes, power, tempC, mode = 'cool') {
+// Rebuilds the airconStat from the raw device response bytes at the state offset,
+// preserving fan speed, swing, and vane settings while updating power/mode/temp.
+//
+// The device response and command formats use different bit encodings for the same fields.
+// Each transform below bridges that gap (verified against homebridge-mhi-wfrac source).
+export function rebuildAirconStat(deviceBytes, power, tempC, mode = 'cool') {
   const modeBits = { cool: 0b00101000, heat: 0b00110000, dry: 0b00011000, fan: 0b00010000, auto: 0b00000000 };
-  const b = Buffer.from(cmdBytes);
-  b[2] = (b[2] & ~0b00000011) | (power ? 0b00000011 : 0b00000010);
-  b[2] = (b[2] & ~0b00111100) | (modeBits[mode] ?? 0b00101000);
+  const b = Buffer.alloc(18, 0);
+
+  // b[2]: power (bits 0-1) + mode (bits 2-5) + vertical swing flag (bits 6-7)
+  // Device response: bit 6 set = auto swing, bit 7 set = non-auto swing
+  // Command format:  bits 6+7 set = auto swing, bit 7 only = non-auto swing
+  // Transform: always set bit 7; bit 6 is already correct from device for both cases
+  b[2] |= power ? 0b00000011 : 0b00000010;
+  b[2] |= modeBits[mode] ?? 0b00101000;
+  b[2] |= 0b10000000;
+  b[2] |= deviceBytes[2] & 0b01000000;
+
+  // b[3]: upper nibble = vertical swing position, lower nibble = fan speed
+  // Device→command: OR 0b10001000 (sets bit 7 for swing, bit 3 for fan)
+  // e.g. fan auto: device=7 (0b0111) → command=15 (0b1111) ✓
+  //      swing pos1: device upper=0 → command upper=8 ✓
+  b[3] = deviceBytes[3] | 0b10001000;
+
+  // b[4]: set temperature — command uses +128 offset, device response does not
   b[4] = Math.floor(tempC / 0.5) + 128;
+
+  // b[8]: required control flag
+  b[8] = deviceBytes[8] | 0b00001000;
+
+  // b[11]: horizontal swing position (lower 5 bits), needs bit 4 set in command
+  // Device→command: OR 0b00010000
+  b[11] = deviceBytes[11] | 0b00010000;
+
+  // b[12]: horizontal swing auto indicator (bits 0-1) + required flag (bit 3)
+  // Device auto=0b01 → command auto=0b11; device non-auto=0b00 → command=0b10
+  // Transform: OR 0b00001010 handles both cases cleanly
+  b[12] = deviceBytes[12] | 0b00001010;
+
   const cmd = addCRC16(addVariable(b));
   const rcv = addCRC16(addVariable(buildReceiveBytes(power, tempC)));
   return Buffer.concat([cmd, rcv]).toString('base64');

--- a/homebridge-mitsubishi-wfrac/encoder/airconStat.js
+++ b/homebridge-mitsubishi-wfrac/encoder/airconStat.js
@@ -65,3 +65,16 @@ export function generateAirconStat(power, tempC, mode = 'cool') {
   const rcv = addCRC16(addVariable(buildReceiveBytes(power, tempC)));
   return Buffer.concat([cmd, rcv]).toString('base64');
 }
+
+// Rebuilds the stat from already-read command bytes, modifying only power/mode/temp.
+// All other bytes (fan speed, swing, vane, etc.) are preserved from the device's current state.
+export function rebuildAirconStat(cmdBytes, power, tempC, mode = 'cool') {
+  const modeBits = { cool: 0b00101000, heat: 0b00110000, dry: 0b00011000, fan: 0b00010000, auto: 0b00000000 };
+  const b = Buffer.from(cmdBytes);
+  b[2] = (b[2] & ~0b00000011) | (power ? 0b00000011 : 0b00000010);
+  b[2] = (b[2] & ~0b00111100) | (modeBits[mode] ?? 0b00101000);
+  b[4] = Math.floor(tempC / 0.5) + 128;
+  const cmd = addCRC16(addVariable(b));
+  const rcv = addCRC16(addVariable(buildReceiveBytes(power, tempC)));
+  return Buffer.concat([cmd, rcv]).toString('base64');
+}

--- a/homebridge-mitsubishi-wfrac/package-lock.json
+++ b/homebridge-mitsubishi-wfrac/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "homebridge-mitsubishi-wfrac",
       "version": "1.0.5",
+      "license": "MIT",
       "dependencies": {
         "@homebridge/plugin-ui-utils": "^2.0.0",
         "axios": "^1.6.0",

--- a/homebridge-mitsubishi-wfrac/package.json
+++ b/homebridge-mitsubishi-wfrac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-mitsubishi-wfrac",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Control Mitsubishi WF-RAC AC units via Homebridge (LAN-only, no cloud required)",
   "main": "src/main.js",
   "type": "module",

--- a/homebridge-mitsubishi-wfrac/src/wfrac-ac.js
+++ b/homebridge-mitsubishi-wfrac/src/wfrac-ac.js
@@ -1,7 +1,7 @@
 // src/wfrac-ac.js
 import axios from 'axios';
 import { parseIndoorTemp } from '../decoder/airconDecode.js';
-import { generateAirconStat } from '../encoder/airconStat.js';
+import { generateAirconStat, rebuildAirconStat } from '../encoder/airconStat.js';
 
 export class MitsubishiWFRACPlatform {
   constructor(log, config, api) {
@@ -125,20 +125,13 @@ class MitsubishiWFRACAccessory {
       const buffer = Buffer.from(b64, 'base64');
       const temp = parseIndoorTemp(b64);
 
-      // 🔍 Debug log for the full raw response
-      this.log(`[${this.name}] Full base64: ${b64}`);
-      this.log(`[${this.name}] Full buffer (hex): ${buffer.toString('hex')}`);
-      this.log(`[${this.name}] Full buffer (bytes): ${Array.from(buffer)}`);
-
-      // Original decoding logic
       const offset = buffer[18] * 4 + 21;
-      const powerOn = (buffer[offset + 2] & 0b00000011) === 1;
-      this.log(`[${this.name}] Power check from offset ${offset + 2} → byte value: ${buffer[offset + 2]} → powerOn: ${powerOn}`);
-      const modeVal = (buffer[5] & 0b00001110) >> 1;
+      const powerOn = (buffer[offset + 2] & 0b00000011) === 3;
+      const modeVal = buffer[offset + 2] & 0b00111100;
 
       this.currentTemp = Number.isFinite(temp) ? temp : this.currentTemp;
       this.isOn = powerOn;
-      this.mode = modeVal === 2 ? 'heat' : 'cool';
+      this.mode = modeVal === 0b00110000 ? 'heat' : 'cool';
 
       this.log(`[${this.name}] Polled temp: ${this.currentTemp}, power: ${this.isOn}, mode: ${this.mode}`);
 
@@ -182,50 +175,48 @@ class MitsubishiWFRACAccessory {
     await this.sendCommand();
   }
 
-  async getCurrentTemp() {
-    try {
-      const payload = {
-        apiVer: "1.0",
-        command: "getAirconStat",
-        deviceId: this.config.deviceId,
-        operatorId: this.config.operatorId,
-        timestamp: Math.floor(Date.now() / 1000),
-      };
-
-      const res = await axios.post(`http://${this.config.host}:51443/beaver/command/getAirconStat`, payload, {
-        headers: { "Content-Type": "application/json" },
-        timeout: 10000,
-      });
-
-      const b64 = res.data.contents.airconStat;
-      const temp = parseIndoorTemp(b64);
-      this.log(`[${this.name}] Decoded temp from device: ${temp}`);
-      return Number.isFinite(temp) ? temp : this.currentTemp;
-    } catch (err) {
-      this.log(`[${this.name}] Error fetching current temperature: ${err.message}`);
-      return this.currentTemp;
-    }
+  getCurrentTemp() {
+    return this.currentTemp;
   }
 
   async sendCommand() {
-    const payload = {
-      apiVer: "1.0",
-      command: "setAirconStat",
-      deviceId: this.config.deviceId,
-      operatorId: this.config.operatorId,
-      timestamp: Math.floor(Date.now() / 1000),
-      contents: {
-        airconId: this.config.airconId,
-        airconStat: generateAirconStat(this.isOn, this.temp, this.mode),
-      },
-    };
+    let airconStat;
 
     try {
-      const res = await axios.post(`http://${this.config.host}:51443/beaver/command/setAirconStat`, payload, {
-        headers: { "Content-Type": "application/json" },
-        timeout: 10000,
-      });
-      this.log(`[${this.name}] AC command sent:`, res.data);
+      const getRes = await axios.post(
+        `http://${this.config.host}:51443/beaver/command/getAirconStat`,
+        {
+          apiVer: "1.0",
+          command: "getAirconStat",
+          deviceId: this.config.deviceId,
+          operatorId: this.config.operatorId,
+          timestamp: Math.floor(Date.now() / 1000),
+        },
+        { headers: { "Content-Type": "application/json" }, timeout: 10000 }
+      );
+      const buffer = Buffer.from(getRes.data.contents.airconStat, 'base64');
+      const offset = buffer[18] * 4 + 21;
+      const cmdBytes = buffer.slice(offset, offset + 18);
+      airconStat = rebuildAirconStat(cmdBytes, this.isOn, this.temp, this.mode);
+    } catch (err) {
+      this.log(`[${this.name}] Could not read current state before send, falling back to defaults: ${err.message}`);
+      airconStat = generateAirconStat(this.isOn, this.temp, this.mode);
+    }
+
+    try {
+      await axios.post(
+        `http://${this.config.host}:51443/beaver/command/setAirconStat`,
+        {
+          apiVer: "1.0",
+          command: "setAirconStat",
+          deviceId: this.config.deviceId,
+          operatorId: this.config.operatorId,
+          timestamp: Math.floor(Date.now() / 1000),
+          contents: { airconId: this.config.airconId, airconStat },
+        },
+        { headers: { "Content-Type": "application/json" }, timeout: 10000 }
+      );
+      this.log(`[${this.name}] Command sent (power=${this.isOn}, mode=${this.mode}, temp=${this.temp})`);
     } catch (err) {
       this.log(`[${this.name}] AC command error: ${err.message}`);
     }

--- a/homebridge-mitsubishi-wfrac/src/wfrac-ac.js
+++ b/homebridge-mitsubishi-wfrac/src/wfrac-ac.js
@@ -1,7 +1,7 @@
 // src/wfrac-ac.js
 import axios from 'axios';
 import { parseIndoorTemp } from '../decoder/airconDecode.js';
-import { generateAirconStat } from '../encoder/airconStat.js';
+import { generateAirconStat, rebuildAirconStat } from '../encoder/airconStat.js';
 
 export class MitsubishiWFRACPlatform {
   constructor(log, config, api) {
@@ -130,12 +130,23 @@ class MitsubishiWFRACAccessory {
       const modeVal = buffer[offset + 2] & 0b00111100;
       const setTemp = buffer[offset + 4] / 2;
 
+      const fanRaw = buffer[offset + 3] & 0b00001111;
+      const fanLabel = { 7: 'auto', 0: 'low1', 1: 'low2', 2: 'high', 6: 'highest' }[fanRaw] ?? `unknown(${fanRaw})`;
+
+      const vSwingAuto = (buffer[offset + 2] & 0b11000000) === 0b01000000;
+      const vSwingPos = (buffer[offset + 3] & 0b11110000) >> 4;
+      const vSwingLabel = vSwingAuto ? 'auto' : `pos${vSwingPos + 1}`;
+
+      const hSwingAuto = (buffer[offset + 12] & 0b00000011) === 0b00000001;
+      const hSwingPos = buffer[offset + 11] & 0b00011111;
+      const hSwingLabel = hSwingAuto ? 'auto' : `pos${hSwingPos + 1}`;
+
       this.currentTemp = Number.isFinite(temp) ? temp : this.currentTemp;
       this.isOn = powerOn;
       this.mode = modeVal === 0b00010000 ? 'heat' : 'cool';
       if (setTemp >= 16 && setTemp <= 30) this.temp = setTemp;
 
-      this.log(`[${this.name}] Polled — current: ${this.currentTemp}°, set: ${this.temp}°, power: ${this.isOn}, mode: ${this.mode}`);
+      this.log(`[${this.name}] Polled — current: ${this.currentTemp}°, set: ${this.temp}°, power: ${this.isOn}, mode: ${this.mode}, fan: ${fanLabel}, vSwing: ${vSwingLabel}, hSwing: ${hSwingLabel}`);
 
       this.service.getCharacteristic(this.api.hap.Characteristic.CurrentTemperature).updateValue(this.currentTemp);
       this.service.getCharacteristic(this.api.hap.Characteristic.CurrentHeaterCoolerState)
@@ -185,6 +196,22 @@ class MitsubishiWFRACAccessory {
   }
 
   async sendCommand() {
+    let airconStat;
+
+    try {
+      const res = await axios.post(
+        `http://${this.config.host}:51443/beaver/command/getAirconStat`,
+        { apiVer: "1.0", command: "getAirconStat", deviceId: this.config.deviceId, operatorId: this.config.operatorId, timestamp: Math.floor(Date.now() / 1000) },
+        { headers: { "Content-Type": "application/json" }, timeout: 10000 }
+      );
+      const buf = Buffer.from(res.data.contents.airconStat, 'base64');
+      const offset = buf[18] * 4 + 21;
+      airconStat = rebuildAirconStat(buf.subarray(offset, offset + 18), this.isOn, this.temp, this.mode);
+    } catch (err) {
+      this.log(`[${this.name}] Could not read device state before send, using defaults: ${err.message}`);
+      airconStat = generateAirconStat(this.isOn, this.temp, this.mode);
+    }
+
     try {
       await axios.post(
         `http://${this.config.host}:51443/beaver/command/setAirconStat`,
@@ -194,7 +221,7 @@ class MitsubishiWFRACAccessory {
           deviceId: this.config.deviceId,
           operatorId: this.config.operatorId,
           timestamp: Math.floor(Date.now() / 1000),
-          contents: { airconId: this.config.airconId, airconStat: generateAirconStat(this.isOn, this.temp, this.mode) },
+          contents: { airconId: this.config.airconId, airconStat },
         },
         { headers: { "Content-Type": "application/json" }, timeout: 10000 }
       );

--- a/homebridge-mitsubishi-wfrac/src/wfrac-ac.js
+++ b/homebridge-mitsubishi-wfrac/src/wfrac-ac.js
@@ -128,12 +128,14 @@ class MitsubishiWFRACAccessory {
       const offset = buffer[18] * 4 + 21;
       const powerOn = (buffer[offset + 2] & 0b00000011) === 3;
       const modeVal = buffer[offset + 2] & 0b00111100;
+      const setTemp = (buffer[offset + 4] - 128) * 0.5;
 
       this.currentTemp = Number.isFinite(temp) ? temp : this.currentTemp;
       this.isOn = powerOn;
       this.mode = modeVal === 0b00110000 ? 'heat' : 'cool';
+      if (setTemp >= 16 && setTemp <= 30) this.temp = setTemp;
 
-      this.log(`[${this.name}] Polled temp: ${this.currentTemp}, power: ${this.isOn}, mode: ${this.mode}`);
+      this.log(`[${this.name}] Polled — current: ${this.currentTemp}°, set: ${this.temp}°, power: ${this.isOn}, mode: ${this.mode}`);
 
       this.service.getCharacteristic(this.api.hap.Characteristic.CurrentTemperature).updateValue(this.currentTemp);
       this.service.getCharacteristic(this.api.hap.Characteristic.CurrentHeaterCoolerState)
@@ -150,6 +152,9 @@ class MitsubishiWFRACAccessory {
         .updateValue(this.mode === 'heat'
           ? this.api.hap.Characteristic.TargetHeaterCoolerState.HEAT
           : this.api.hap.Characteristic.TargetHeaterCoolerState.COOL);
+
+      this.service.getCharacteristic(this.api.hap.Characteristic.HeatingThresholdTemperature).updateValue(this.temp);
+      this.service.getCharacteristic(this.api.hap.Characteristic.CoolingThresholdTemperature).updateValue(this.temp);
 
     } catch (err) {
       this.log(`[${this.name}] Polling error: ${err.message}`);

--- a/homebridge-mitsubishi-wfrac/src/wfrac-ac.js
+++ b/homebridge-mitsubishi-wfrac/src/wfrac-ac.js
@@ -1,7 +1,7 @@
 // src/wfrac-ac.js
 import axios from 'axios';
 import { parseIndoorTemp } from '../decoder/airconDecode.js';
-import { generateAirconStat, rebuildAirconStat } from '../encoder/airconStat.js';
+import { generateAirconStat } from '../encoder/airconStat.js';
 
 export class MitsubishiWFRACPlatform {
   constructor(log, config, api) {
@@ -126,13 +126,13 @@ class MitsubishiWFRACAccessory {
       const temp = parseIndoorTemp(b64);
 
       const offset = buffer[18] * 4 + 21;
-      const powerOn = (buffer[offset + 2] & 0b00000011) === 3;
+      const powerOn = (buffer[offset + 2] & 0b00000011) === 1;
       const modeVal = buffer[offset + 2] & 0b00111100;
-      const setTemp = (buffer[offset + 4] - 128) * 0.5;
+      const setTemp = buffer[offset + 4] / 2;
 
       this.currentTemp = Number.isFinite(temp) ? temp : this.currentTemp;
       this.isOn = powerOn;
-      this.mode = modeVal === 0b00110000 ? 'heat' : 'cool';
+      this.mode = modeVal === 0b00010000 ? 'heat' : 'cool';
       if (setTemp >= 16 && setTemp <= 30) this.temp = setTemp;
 
       this.log(`[${this.name}] Polled — current: ${this.currentTemp}°, set: ${this.temp}°, power: ${this.isOn}, mode: ${this.mode}`);
@@ -185,29 +185,6 @@ class MitsubishiWFRACAccessory {
   }
 
   async sendCommand() {
-    let airconStat;
-
-    try {
-      const getRes = await axios.post(
-        `http://${this.config.host}:51443/beaver/command/getAirconStat`,
-        {
-          apiVer: "1.0",
-          command: "getAirconStat",
-          deviceId: this.config.deviceId,
-          operatorId: this.config.operatorId,
-          timestamp: Math.floor(Date.now() / 1000),
-        },
-        { headers: { "Content-Type": "application/json" }, timeout: 10000 }
-      );
-      const buffer = Buffer.from(getRes.data.contents.airconStat, 'base64');
-      const offset = buffer[18] * 4 + 21;
-      const cmdBytes = buffer.slice(offset, offset + 18);
-      airconStat = rebuildAirconStat(cmdBytes, this.isOn, this.temp, this.mode);
-    } catch (err) {
-      this.log(`[${this.name}] Could not read current state before send, falling back to defaults: ${err.message}`);
-      airconStat = generateAirconStat(this.isOn, this.temp, this.mode);
-    }
-
     try {
       await axios.post(
         `http://${this.config.host}:51443/beaver/command/setAirconStat`,
@@ -217,7 +194,7 @@ class MitsubishiWFRACAccessory {
           deviceId: this.config.deviceId,
           operatorId: this.config.operatorId,
           timestamp: Math.floor(Date.now() / 1000),
-          contents: { airconId: this.config.airconId, airconStat },
+          contents: { airconId: this.config.airconId, airconStat: generateAirconStat(this.isOn, this.temp, this.mode) },
         },
         { headers: { "Content-Type": "application/json" }, timeout: 10000 }
       );


### PR DESCRIPTION
**Fixed:**
- Fan speed, vertical swing, and horizontal swing no longer reset to auto 
  when turning the unit on/off from HomeKit — settings set in the native 
  app are now read from the device before each command and preserved
- Set temperature now reads correctly from the device during polling 
  (was using wrong byte offset, always showing 22°C after restart)
- Power state polling fixed — device returns bit 0 only when ON, not bits 0+1
- Heat mode detection fixed — device response uses 0x10 for heat, 0x08 for cool 
  (confirmed against homebridge-mhi-wfrac protocol reference)
- Reverted broken `rebuildAirconStat` approach that fed device response bytes 
  directly back as command bytes (these are different formats)